### PR TITLE
[Feat] 생성자, 수정자를 자동으로 관리할 수 있도록 JPA Auditing 설정 추가

### DIFF
--- a/src/main/java/net/blogteamthreecoderhivebe/config/JpaConfig.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/config/JpaConfig.java
@@ -1,13 +1,21 @@
 package net.blogteamthreecoderhivebe.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @EnableJpaAuditing
 @Configuration
 public class JpaConfig {
-//    @Bean
-//    public AuditorAware<String> auditorAware() {
-//        return () -> Optional.ofNullable("coderhive");
-//    }
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> Optional.of(UUID.randomUUID().toString());
+
+        // 추후 Spring Security의 Authentication을 가져와서 사용자명을 반환하도록 변경 예정
+        // return () -> Optional.of(SecurityContextHolder.getContext().getAuthentication().getName());
+    }
 }

--- a/src/main/java/net/blogteamthreecoderhivebe/entity/AuditingFields.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/entity/AuditingFields.java
@@ -4,9 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -16,8 +14,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
-@SuperBuilder
-@NoArgsConstructor
 @Getter
 @ToString
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/net/blogteamthreecoderhivebe/entity/Member.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/entity/Member.java
@@ -2,7 +2,6 @@ package net.blogteamthreecoderhivebe.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
 import net.blogteamthreecoderhivebe.entity.constant.MemberCareer;
 import net.blogteamthreecoderhivebe.entity.constant.MemberLevel;
 import net.blogteamthreecoderhivebe.entity.constant.MemberRole;
@@ -11,9 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-@SuperBuilder
 @ToString(callSuper = true, exclude = {"job", "listPosts"})
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity

--- a/src/main/java/net/blogteamthreecoderhivebe/service/MemberService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/service/MemberService.java
@@ -90,18 +90,17 @@ public class MemberService {
                                 String introduction,
                                 Job job
                                 ) {
-        return MemberDto.from(memberRepository.save(Member.builder()
-                                        .nickname(nickname)
-                                        .email(email)
-                                        .level(level)
-                                        .career(career)
-                                        .memberRole(memberRole)
-                                        .profileImageUrl(profileImageUrl)
-                                        .introduction(introduction)
-                                        .job(job)
-                                        .createdBy(nickname)
-                                        .modifiedBy(nickname)
-                                        .build())
+        return MemberDto.from(memberRepository.save(
+                Member.builder()
+                        .nickname(nickname)
+                        .email(email)
+                        .level(level)
+                        .career(career)
+                        .memberRole(memberRole)
+                        .profileImageUrl(profileImageUrl)
+                        .introduction(introduction)
+                        .job(job)
+                        .build())
         );
     }
 
@@ -116,11 +115,10 @@ public class MemberService {
 
     @Transactional
     public MemberDto saveMember(String email) {
-        return MemberDto.from(memberRepository.save(Member.builder()
-                .email(email)
-                .modifiedBy(email)
-                .createdBy(email)
-                .build())
+        return MemberDto.from(memberRepository.save(
+                Member.builder()
+                        .email(email)
+                        .build())
         );
     }
 }

--- a/src/test/java/net/blogteamthreecoderhivebe/entity/AuditingFieldsTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/entity/AuditingFieldsTest.java
@@ -1,0 +1,70 @@
+package net.blogteamthreecoderhivebe.entity;
+
+import net.blogteamthreecoderhivebe.repository.JobRepository;
+import net.blogteamthreecoderhivebe.repository.LocationRepository;
+import net.blogteamthreecoderhivebe.repository.MemberRepository;
+import net.blogteamthreecoderhivebe.repository.PostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class AuditingFieldsTest {
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    JobRepository jobRepository;
+    @Autowired
+    LocationRepository locationRepository;
+
+    @DisplayName("회원 등록시 생성일, 수정일, 생성자, 수정자 자동으로 생성")
+    @Test
+    void member() {
+        // given
+        Member member = Member.builder().email("test@test.com").build();
+
+        // when
+        memberRepository.save(member);
+
+        // then
+        assertThat(member.getCreatedAt()).isNotNull();
+        assertThat(member.getModifiedAt()).isNotNull();
+        assertThat(member.getCreatedBy()).isNotNull();
+        assertThat(member.getModifiedBy()).isNotNull();
+    }
+
+    @DisplayName("게시물 등록시 생성일, 수정일, 생성자, 수정자가 자동으로 생성")
+    @Test
+    void post() {
+        // given
+        Member member = Member.builder().email("test@test.com").build();
+        memberRepository.save(member);
+
+        Job job = jobRepository.findById(1L).get();
+        Location location = locationRepository.findById(1L).get();
+
+        Post post = Post.builder()
+                .member(member)
+                .location(location)
+                .job(job)
+                .build();
+
+        Post savedPost = postRepository.save(post);
+
+        // when
+        Post findPost = postRepository.findById(savedPost.getId()).get();
+
+        // then
+        assertThat(findPost.getCreatedAt()).isNotNull();
+        assertThat(findPost.getModifiedAt()).isNotNull();
+        assertThat(findPost.getCreatedBy()).isNotNull();
+        assertThat(findPost.getModifiedBy()).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary
여러 엔티티에 공통 속성으로 사용되고 있는 `등록자`, `수정자`를 JPA Auditing 기능을 활용해 자동으로 채워질 수 있도록 설정하였습니다.
현재는 등록자, 수정자로 `uuid` 값을 사용하지만 추후 시큐리티 인증 객체의 이름을 사용하도록 변경될 예정입니다.

## Describe your changes
- [x] --

## Issue number and link
#44