### PR TITLE
[Refactor] 회원 등록 기능 수정 및 사용자 유효성(유저, 게스트) 검사 요청 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     // validation
-    //implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     //testImplementation 'com.h2database:h2'
 
     // QueryDSL JPA
@@ -61,7 +61,7 @@ tasks.withType(JavaCompile) {
 
 // java source set 에 querydsl QClass 위치 추가
 sourceSets {
-    main.java.srcDirs += [ generated ]
+    main.java.srcDirs += [generated]
 }
 
 // gradle clean 시에 QClass 디렉토리 삭제

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/JobService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/JobService.java
@@ -7,11 +7,10 @@ import net.blogteamthreecoderhivebe.domain.info.repository.JobRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class JobService {
-
     private static final String NOT_FOUND_JOB = "ID[%s] 직무를 찾을 수 없습니다.";
 
     private final JobRepository jobRepository;

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/JobService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/JobService.java
@@ -1,0 +1,23 @@
+package net.blogteamthreecoderhivebe.domain.info.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import net.blogteamthreecoderhivebe.domain.info.entity.Job;
+import net.blogteamthreecoderhivebe.domain.info.repository.JobRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class JobService {
+
+    private static final String NOT_FOUND_JOB = "ID[%s] 직무를 찾을 수 없습니다.";
+
+    private final JobRepository jobRepository;
+
+    public Job findOne(Long jobId) {
+        return jobRepository.findById(jobId)
+                .orElseThrow(() -> new EntityNotFoundException(String.format(NOT_FOUND_JOB, jobId)));
+    }
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/LocationService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/LocationService.java
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Service
 public class LocationService {
-
     private static final String NOT_FOUND_LOCATION = "ID[%s] 지역을 찾을 수 없습니다.";
 
     private final LocationRepository locationRepository;

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/LocationService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/LocationService.java
@@ -1,0 +1,24 @@
+package net.blogteamthreecoderhivebe.domain.info.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import net.blogteamthreecoderhivebe.domain.info.entity.Location;
+import net.blogteamthreecoderhivebe.domain.info.repository.LocationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class LocationService {
+
+    private static final String NOT_FOUND_LOCATION = "ID[%s] 지역을 찾을 수 없습니다.";
+
+    private final LocationRepository locationRepository;
+
+    public Location findOne(Long locationId) {
+        return locationRepository.findById(locationId)
+                .orElseThrow(() -> new EntityNotFoundException(String.format(NOT_FOUND_LOCATION, locationId)));
+    }
+}
+

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/SkillService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/info/service/SkillService.java
@@ -1,0 +1,22 @@
+package net.blogteamthreecoderhivebe.domain.info.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import net.blogteamthreecoderhivebe.domain.info.entity.Skill;
+import net.blogteamthreecoderhivebe.domain.info.repository.SkillRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class SkillService {
+    private static final String NOT_FOUND_SKILL = "ID[%s] 기술을 찾을 수 없습니다.";
+
+    private final SkillRepository skillRepository;
+
+    public Skill findOne(Long skillId) {
+        return skillRepository.findById(skillId)
+                .orElseThrow(() -> new EntityNotFoundException(String.format(NOT_FOUND_SKILL, skillId)));
+    }
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/controller/MemberController.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/controller/MemberController.java
@@ -3,17 +3,16 @@ package net.blogteamthreecoderhivebe.domain.member.controller;
 import lombok.RequiredArgsConstructor;
 import net.blogteamthreecoderhivebe.domain.heart.service.HeartService;
 import net.blogteamthreecoderhivebe.domain.member.dto.MemberWithPostDto;
+import net.blogteamthreecoderhivebe.domain.member.dto.SignUpDto;
 import net.blogteamthreecoderhivebe.domain.member.dto.request.SignUpRequest;
 import net.blogteamthreecoderhivebe.domain.member.dto.response.MemberInfoWithPostResponse;
 import net.blogteamthreecoderhivebe.domain.member.dto.response.MyInfoWithPostResponse;
+import net.blogteamthreecoderhivebe.domain.member.dto.response.SignUpResponse;
 import net.blogteamthreecoderhivebe.domain.member.service.MemberService;
 import net.blogteamthreecoderhivebe.global.auth.dto.MemberPrincipal;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.net.URI;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -23,18 +22,36 @@ public class MemberController {
     private final MemberService memberService;
     private final HeartService heartService;
 
+    /**
+     * 회원 가입 - 추가 정보 등록
+     * need   > SignUpRequest, MemberPrincipal
+     * return > SignInResponse
+     * TODO 1) Dto 생성 / SignUpRequest, SignUpDto, SignInResponse
+     * TODO 2) 사용자 정보 유효성 검사 / email, nickname, jobId, career, level
+     * TODO 3) 사용자 정보 저장
+     */
     @PostMapping
-    public ResponseEntity<String> signUp(@RequestBody SignUpRequest signUpRequest,
-                                         @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-        Long memberId = memberService.save(signUpRequest, memberPrincipal.getEmail());
+    //public SingUpResponse signUp(@RequestBody @Valid SignUpRequest signUpRequest,
+    public SignUpResponse signUp(@RequestBody SignUpRequest signUpRequest,
+                                 @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+//        Long memberId = memberService.signUp(SignUpDto.of(signUpRequest, memberPrincipal.getEmail()));
+        SignUpResponse signUpResponse = memberService.signUp(SignUpDto.of(signUpRequest, memberPrincipal.getEmail()));
 
-        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
-                .path("/{id}")
-                .buildAndExpand(memberId)
-                .toUri();
-
-        return ResponseEntity.created(location).body("회원 가입 성공");
+//        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+//                .path("/{id}")
+//                .buildAndExpand(memberId)
+//                .toUri();
+        return signUpResponse;
+        //return ResponseEntity.created(location).body("회원 가입 성공");
     }
+
+    /**
+     * 유효한 회원인지 확인 기능
+     * need   > email
+     * return > SignUpResponse
+     * TODO 1)
+     */
+
 
     @GetMapping("/my")
     public MyInfoWithPostResponse searchMyInfo(@RequestParam Long memberId) {

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/controller/MemberController.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/controller/MemberController.java
@@ -47,9 +47,7 @@ public class MemberController {
      * 유효한 회원인지 확인 기능 - ROLE_USER
      * need   > email, MemberPrincipal
      * return > SignUpResponse
-     * TODO
-     * 1) email과 principal-email 검증
-     * 2)
+     * TODO 1) email과 principal-email 검증
      */
     @GetMapping("/{email}/valid")
     public SignUpResponse validationMember(@PathVariable String email,

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/controller/MemberController.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/controller/MemberController.java
@@ -26,9 +26,7 @@ public class MemberController {
      * 회원 가입 - 추가 정보 등록
      * need   > SignUpRequest, MemberPrincipal
      * return > SignInResponse
-     * TODO 1) Dto 생성 / SignUpRequest, SignUpDto, SignInResponse
-     * TODO 2) 사용자 정보 유효성 검사 / email, nickname, jobId, career, level
-     * TODO 3) 사용자 정보 저장
+     * TODO 1) 사용자 정보 유효성 검사 / email, nickname, jobId, career, level
      */
     @PostMapping
     //public SingUpResponse signUp(@RequestBody @Valid SignUpRequest signUpRequest,
@@ -46,11 +44,26 @@ public class MemberController {
     }
 
     /**
-     * 유효한 회원인지 확인 기능
-     * need   > email
+     * 유효한 회원인지 확인 기능 - ROLE_USER
+     * need   > email, MemberPrincipal
      * return > SignUpResponse
-     * TODO 1)
+     * TODO
+     * 1) email과 principal-email 검증
+     * 2)
      */
+    @GetMapping("/{email}/valid")
+    public SignUpResponse validationMember(@PathVariable String email,
+                                           @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        // principal 검증
+        if (memberPrincipal == null) {
+            // TODO 1) 로그인 안되어 있음
+        }
+        // email과 principal-email 검증
+        if (!email.equals(memberPrincipal.getEmail())) {
+            // TODO 2) "유효성 검사할 이메일"과 "로그인한 이메일" 같지 않음
+        }
+        return memberService.validMember(email);
+    }
 
 
     @GetMapping("/my")

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/SignUpDto.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/SignUpDto.java
@@ -21,7 +21,7 @@ public record SignUpDto(
         return SignUpDto.builder()
                 .email(email)
                 .nickname(signUpRequest.nickname())
-                .jobId(signUpRequest.jobId())
+                .jobId(Long.parseLong(signUpRequest.jobId()))
                 .memberLevel(MemberLevel.find(signUpRequest.level()))
                 .memberCareer(MemberCareer.find(signUpRequest.career()))
                 .build();

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/SignUpDto.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/SignUpDto.java
@@ -1,0 +1,40 @@
+package net.blogteamthreecoderhivebe.domain.member.dto;
+
+import lombok.Builder;
+import net.blogteamthreecoderhivebe.domain.info.entity.Job;
+import net.blogteamthreecoderhivebe.domain.member.constant.MemberCareer;
+import net.blogteamthreecoderhivebe.domain.member.constant.MemberLevel;
+import net.blogteamthreecoderhivebe.domain.member.dto.request.SignUpRequest;
+import net.blogteamthreecoderhivebe.domain.member.entity.Member;
+
+import static net.blogteamthreecoderhivebe.domain.member.constant.MemberRole.USER;
+
+@Builder
+public record SignUpDto(
+        String email,
+        String nickname,
+        long jobId,
+        MemberLevel memberLevel,
+        MemberCareer memberCareer
+) {
+    public static SignUpDto of(SignUpRequest signUpRequest, String email) {
+        return SignUpDto.builder()
+                .email(email)
+                .nickname(signUpRequest.nickname())
+                .jobId(signUpRequest.jobId())
+                .memberLevel(MemberLevel.find(signUpRequest.level()))
+                .memberCareer(MemberCareer.find(signUpRequest.career()))
+                .build();
+    }
+
+    public static Member toMemberWithJob(SignUpDto dto, Job job) {
+        return Member.builder()
+                .email(dto.email)
+                .nickname(dto.nickname)
+                .career(dto.memberCareer)
+                .job(job)
+                .level(dto.memberLevel)
+                .memberRole(USER)
+                .build();
+    }
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/request/SignUpRequest.java
@@ -1,9 +1,21 @@
 package net.blogteamthreecoderhivebe.domain.member.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
 public record SignUpRequest(
+        @NotBlank(message = "닉네임은 필수 입력값입니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,10}$", message = "닉네임은 특수문자를 포함하지 않은 2~10자리여야 합니다.")
         String nickname,
-        long jobId,
+        @NotNull(message = "직무는 필수 입력값입니다.")
+        @Pattern(regexp = "^[0-9]{1,10}$", message = "직무는 1 이상의 1~10자리 숫자여야 합니다.")
+        String jobId,
+        @NotBlank(message = "레벨은 필수 입력값입니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9-_~]{1,20}$", message = "레벨은 정해진 description을 만족해야 합니다.")
         String level,
+        @NotBlank(message = "경력은 필수 입력값입니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9-_~]{1,20}$", message = "경력은 정해진 description을 만족해야 합니다.")
         String career
 ) {
 }

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/response/SignUpResponse.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/response/SignUpResponse.java
@@ -1,0 +1,21 @@
+package net.blogteamthreecoderhivebe.domain.member.dto.response;
+
+import lombok.Builder;
+import net.blogteamthreecoderhivebe.domain.member.entity.Member;
+
+@Builder
+public record SignUpResponse(
+        boolean isSignUp,
+        String email,
+        String nickname,
+        String profileThumbUrl
+) {
+    public static SignUpResponse from(Member member) {
+        return SignUpResponse.builder()
+                .isSignUp(true)
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileThumbUrl(member.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/response/SignUpResponse.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/dto/response/SignUpResponse.java
@@ -3,6 +3,8 @@ package net.blogteamthreecoderhivebe.domain.member.dto.response;
 import lombok.Builder;
 import net.blogteamthreecoderhivebe.domain.member.entity.Member;
 
+import static net.blogteamthreecoderhivebe.domain.member.constant.MemberRole.USER;
+
 @Builder
 public record SignUpResponse(
         boolean isSignUp,
@@ -12,7 +14,7 @@ public record SignUpResponse(
 ) {
     public static SignUpResponse from(Member member) {
         return SignUpResponse.builder()
-                .isSignUp(true)
+                .isSignUp(member.getMemberRole() == USER ? true : false)
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .profileThumbUrl(member.getProfileImageUrl())

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/entity/ApplicationInfo.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/entity/ApplicationInfo.java
@@ -22,7 +22,7 @@ public class ApplicationInfo {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_job_id")
+    @JoinColumn(name = "recruitment_job_id")
     private RecruitmentJob recruitmentJob;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/entity/Member.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/entity/Member.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static net.blogteamthreecoderhivebe.domain.member.constant.MemberRole.USER;
+
 @Builder
 @Getter
 @ToString(callSuper = true, exclude = {"job", "hearts"})
@@ -58,6 +60,7 @@ public class Member extends AuditingFields {
     public void update(SignUpDto signUpDto, Job job) {
         this.nickname = signUpDto.nickname();
         this.job = job;
+        this.memberRole = USER;
         this.level = signUpDto.memberLevel();
         this.career = signUpDto.memberCareer();
     }

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/entity/Member.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/entity/Member.java
@@ -7,6 +7,7 @@ import net.blogteamthreecoderhivebe.domain.info.entity.Job;
 import net.blogteamthreecoderhivebe.domain.member.constant.MemberCareer;
 import net.blogteamthreecoderhivebe.domain.member.constant.MemberLevel;
 import net.blogteamthreecoderhivebe.domain.member.constant.MemberRole;
+import net.blogteamthreecoderhivebe.domain.member.dto.SignUpDto;
 import net.blogteamthreecoderhivebe.global.common.AuditingFields;
 
 import java.util.ArrayList;
@@ -50,6 +51,16 @@ public class Member extends AuditingFields {
     @Builder.Default
     @OneToMany(mappedBy = "member")
     private List<Heart> hearts = new ArrayList<>();
+
+    // TODO : Member update 메소드 생성
+    // expected 1) 회원가입 기능
+    // expected 2) 프로필 수정 기능
+    public void update(SignUpDto signUpDto, Job job) {
+        this.nickname = signUpDto.nickname();
+        this.job = job;
+        this.level = signUpDto.memberLevel();
+        this.career = signUpDto.memberCareer();
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/service/MemberService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/service/MemberService.java
@@ -5,11 +5,10 @@ import lombok.RequiredArgsConstructor;
 import net.blogteamthreecoderhivebe.domain.info.entity.Job;
 import net.blogteamthreecoderhivebe.domain.info.repository.JobRepository;
 import net.blogteamthreecoderhivebe.domain.member.constant.ApplicationResult;
-import net.blogteamthreecoderhivebe.domain.member.constant.MemberCareer;
-import net.blogteamthreecoderhivebe.domain.member.constant.MemberLevel;
 import net.blogteamthreecoderhivebe.domain.member.dto.MemberDto;
 import net.blogteamthreecoderhivebe.domain.member.dto.MemberWithPostDto;
-import net.blogteamthreecoderhivebe.domain.member.dto.request.SignUpRequest;
+import net.blogteamthreecoderhivebe.domain.member.dto.SignUpDto;
+import net.blogteamthreecoderhivebe.domain.member.dto.response.SignUpResponse;
 import net.blogteamthreecoderhivebe.domain.member.entity.Member;
 import net.blogteamthreecoderhivebe.domain.member.repository.MemberRepository;
 import net.blogteamthreecoderhivebe.domain.member.repository.MemberSkillRepository;
@@ -22,8 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-
-import static net.blogteamthreecoderhivebe.domain.member.constant.MemberRole.USER;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -81,21 +78,9 @@ public class MemberService {
      * 회원 가입
      */
     @Transactional
-    public Long save(SignUpRequest signUpRequest, String email) {
-        Job job = jobRepository.findById(signUpRequest.jobId()).orElseThrow();
-        MemberCareer memberCareer = MemberCareer.find(signUpRequest.career());
-        MemberLevel memberLevel = MemberLevel.find(signUpRequest.level());
-
-        Member member = Member.builder()
-                .email(email)
-                .nickname(signUpRequest.nickname())
-                .job(job)
-                .career(memberCareer)
-                .level(memberLevel)
-                .memberRole(USER)
-                .build();
-
-        return memberRepository.save(member).getId();
+    public SignUpResponse signUp(SignUpDto signUpDto) {
+        Job job = jobRepository.findById(signUpDto.jobId()).orElseThrow();
+        return SignUpResponse.from(memberRepository.save(signUpDto.toMemberWithJob(signUpDto, job)));
     }
 
     /**

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/service/MemberService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/service/MemberService.java
@@ -41,7 +41,7 @@ public class MemberService {
                 .orElseThrow(() -> new EntityNotFoundException("멤버가 없습니다 - memberId: " + memberId));
     }
 
-    private Member searchMember(String email) {
+    public Member searchMember(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new EntityNotFoundException("멤버가 없습니다 - email:" + email));
     }

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/service/MemberService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/service/MemberService.java
@@ -89,4 +89,12 @@ public class MemberService {
     public boolean isNewMember(String email) {
         return memberRepository.findByEmail(email).isEmpty();
     }
+
+    /**
+     * 사용자의 ROLE 확인
+     */
+    public SignUpResponse validMember(String email) {
+        return SignUpResponse.from(memberRepository.findByEmail(email).orElseThrow());
+    }
+
 }

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/constant/PostCategory.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/constant/PostCategory.java
@@ -2,6 +2,7 @@ package net.blogteamthreecoderhivebe.domain.post.constant;
 
 import lombok.Getter;
 
+@Getter
 public enum PostCategory {
     PROJECT("project"),
     STUDY("study");
@@ -9,8 +10,10 @@ public enum PostCategory {
     @Getter
     private final String description;
 
-    PostCategory(String description) {
-        this.description = description;
+    private final String key;
+
+    PostCategory(String key) {
+        this.key = key;
     }
 }
 

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/constant/PostCategory.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/constant/PostCategory.java
@@ -2,18 +2,26 @@ package net.blogteamthreecoderhivebe.domain.post.constant;
 
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
 public enum PostCategory {
     PROJECT("project"),
     STUDY("study");
 
-    @Getter
-    private final String description;
+    private static final String NOT_FOUND_CATEGORY = "[%s] 카테고리를 찾을 수 없습니다.";
 
     private final String key;
 
     PostCategory(String key) {
         this.key = key;
+    }
+
+    public static PostCategory find(String key) {
+        return Arrays.stream(values())
+                .filter(category -> category.key.equals(key))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(String.format(NOT_FOUND_CATEGORY, key)));
     }
 }
 

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/controller/PostController.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/controller/PostController.java
@@ -1,0 +1,25 @@
+package net.blogteamthreecoderhivebe.domain.post.controller;
+
+import lombok.RequiredArgsConstructor;
+import net.blogteamthreecoderhivebe.domain.post.service.PostService;
+import net.blogteamthreecoderhivebe.global.auth.dto.MemberPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static net.blogteamthreecoderhivebe.domain.post.dto.request.PostRequestDto.SaveRequest;
+import static net.blogteamthreecoderhivebe.domain.post.dto.response.PostResponseDto.SaveResponse;
+
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+@RestController
+public class PostController {
+    private final PostService postService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public SaveResponse register(@RequestBody SaveRequest request,
+                                 @AuthenticationPrincipal MemberPrincipal principal) {
+        return postService.save(request, principal.getEmail());
+    }
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/dto/request/PostRequestDto.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/dto/request/PostRequestDto.java
@@ -1,0 +1,17 @@
+package net.blogteamthreecoderhivebe.domain.post.dto.request;
+
+import java.util.List;
+
+public class PostRequestDto {
+    public record SaveRequest(
+            String category,
+            String title,
+            Long locationId,
+            List<RecruitmentJobRequestDto.SaveRequest> recruitmentJobs,
+            Long myJobId,
+            List<Long> skillIds,
+            String thumbImageUrl,
+            String content,
+            String platforms
+    ) {}
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/dto/request/RecruitmentJobRequestDto.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/dto/request/RecruitmentJobRequestDto.java
@@ -1,0 +1,5 @@
+package net.blogteamthreecoderhivebe.domain.post.dto.request;
+
+public class RecruitmentJobRequestDto {
+    public record SaveRequest(Long jobId, int number) {}
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/dto/response/PostResponseDto.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/dto/response/PostResponseDto.java
@@ -1,0 +1,5 @@
+package net.blogteamthreecoderhivebe.domain.post.dto.response;
+
+public class PostResponseDto{
+    public record SaveResponse(Long postId) {}
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/entity/Post.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/entity/Post.java
@@ -16,9 +16,9 @@ import java.util.Objects;
 
 @Builder
 @Getter
-@ToString(callSuper = true, exclude = {"member", "recruitmentJobs", "hearts", "location", "job"})
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString(callSuper = true, exclude = {"member", "recruitmentJobs", "hearts", "location", "job"})
 @Table(indexes = @Index(columnList = "modifiedAt DESC"))
 @Entity
 public class Post extends AuditingFields {

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/entity/RecruitmentJob.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/entity/RecruitmentJob.java
@@ -4,11 +4,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import net.blogteamthreecoderhivebe.domain.info.entity.Job;
 
-@Builder
 @Getter
 @ToString(exclude = {"post", "job"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Entity
 public class RecruitmentJob {
     @Id
@@ -28,7 +26,18 @@ public class RecruitmentJob {
 
     private int passNumber;
 
-    public void addPost(Post post) {
+    @Builder
+    public RecruitmentJob(Post post, Job job, int number, int passNumber) {
+        setPost(post);
+        this.job = job;
+        this.number = number;
+        this.passNumber = passNumber;
+    }
+
+    /**
+     * 연관관계 편의 메서드
+     */
+    private void setPost(Post post) {
         this.post = post;
         post.getRecruitmentJobs().add(this);
     }

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/entity/RecruitmentSkill.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/entity/RecruitmentSkill.java
@@ -1,14 +1,15 @@
 package net.blogteamthreecoderhivebe.domain.post.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import net.blogteamthreecoderhivebe.domain.info.entity.Skill;
 
-@Builder
 @Getter
 @ToString(exclude = {"skill", "post"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Entity
 public class RecruitmentSkill {
     @Id
@@ -23,4 +24,13 @@ public class RecruitmentSkill {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    private RecruitmentSkill(Skill skill, Post post) {
+        this.skill = skill;
+        this.post = post;
+    }
+
+    public static RecruitmentSkill of(Skill skill, Post post) {
+        return new RecruitmentSkill(skill, post);
+    }
 }

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/service/PostService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/service/PostService.java
@@ -30,6 +30,8 @@ public class PostService {
     private final MemberService memberService;
     private final PostRepository postRepository;
     private final LocationService locationService;
+    private final RecruitmentJobService recruitmentJobService;
+    private final RecruitmentSkillService recruitmentSkillService;
     private final RecruitmentSkillRepository recruitmentSkillRepository;
 
     /**
@@ -49,6 +51,9 @@ public class PostService {
                 .build();
 
         Long postId = postRepository.save(post).getId();
+        recruitmentSkillService.save(request.skillIds(), post);
+        recruitmentJobService.save(request.recruitmentJobs(), post);
+
         return new SaveResponse(postId);
     }
 

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/service/PostService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/service/PostService.java
@@ -1,6 +1,9 @@
 package net.blogteamthreecoderhivebe.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
+import net.blogteamthreecoderhivebe.domain.info.service.JobService;
+import net.blogteamthreecoderhivebe.domain.info.service.LocationService;
+import net.blogteamthreecoderhivebe.domain.member.service.MemberService;
 import net.blogteamthreecoderhivebe.domain.post.constant.PostCategory;
 import net.blogteamthreecoderhivebe.domain.post.constant.PostStatus;
 import net.blogteamthreecoderhivebe.domain.post.dto.PostWithApplyNumberDto;
@@ -16,12 +19,38 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static net.blogteamthreecoderhivebe.domain.post.dto.request.PostRequestDto.SaveRequest;
+import static net.blogteamthreecoderhivebe.domain.post.dto.response.PostResponseDto.SaveResponse;
+
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class PostService {
+    private final JobService jobService;
+    private final MemberService memberService;
     private final PostRepository postRepository;
+    private final LocationService locationService;
     private final RecruitmentSkillRepository recruitmentSkillRepository;
+
+    /**
+     * 게시글 등록
+     */
+    @Transactional
+    public SaveResponse save(SaveRequest request, String memberEmail) {
+        Post post = Post.builder()
+                .member(memberService.searchMember(memberEmail))
+                .job(jobService.findOne(request.myJobId()))
+                .location(locationService.findOne(request.locationId()))
+                .postCategory(PostCategory.find(request.category()))
+                .title(request.title())
+                .content(request.content())
+                .thumbImageUrl(request.thumbImageUrl())
+                .platforms(request.platforms())
+                .build();
+
+        Long postId = postRepository.save(post).getId();
+        return new SaveResponse(postId);
+    }
 
     public Page<PostWithApplyNumberDto> searchPost(PostCategory postCategory,
                                                    List<Long> regions,

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/service/RecruitmentJobService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/service/RecruitmentJobService.java
@@ -1,0 +1,32 @@
+package net.blogteamthreecoderhivebe.domain.post.service;
+
+import lombok.RequiredArgsConstructor;
+import net.blogteamthreecoderhivebe.domain.info.service.JobService;
+import net.blogteamthreecoderhivebe.domain.post.entity.Post;
+import net.blogteamthreecoderhivebe.domain.post.entity.RecruitmentJob;
+import net.blogteamthreecoderhivebe.domain.post.repository.RecruitmentJobRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static net.blogteamthreecoderhivebe.domain.post.dto.request.RecruitmentJobRequestDto.SaveRequest;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class RecruitmentJobService {
+    private final JobService jobService;
+    private final RecruitmentJobRepository recruitmentJobRepository;
+
+    public void save(List<SaveRequest> saveRequests, Post post) {
+        for (SaveRequest saveRequest : saveRequests) {
+            RecruitmentJob recruitmentJob = RecruitmentJob.builder()
+                    .post(post)
+                    .job(jobService.findOne(saveRequest.jobId()))
+                    .number(saveRequest.number())
+                    .build();
+            recruitmentJobRepository.save(recruitmentJob);
+        }
+    }
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/service/RecruitmentSkillService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/service/RecruitmentSkillService.java
@@ -1,0 +1,26 @@
+package net.blogteamthreecoderhivebe.domain.post.service;
+
+import lombok.RequiredArgsConstructor;
+import net.blogteamthreecoderhivebe.domain.info.service.SkillService;
+import net.blogteamthreecoderhivebe.domain.post.entity.Post;
+import net.blogteamthreecoderhivebe.domain.post.entity.RecruitmentSkill;
+import net.blogteamthreecoderhivebe.domain.post.repository.RecruitmentSkillRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class RecruitmentSkillService {
+    private final SkillService skillService;
+    private final RecruitmentSkillRepository recruitmentSkillRepository;
+
+    public void save(List<Long> skillIds, Post post) {
+        for (Long skillId : skillIds) {
+            RecruitmentSkill recruitmentSkill = RecruitmentSkill.of(skillService.findOne(skillId), post);
+            recruitmentSkillRepository.save(recruitmentSkill);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,12 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+        highlight_sql: true
         default_batch_fetch_size: 100
     defer-datasource-initialization: true
 
   sql.init.mode: always
+
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: trace

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/JobServiceTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/JobServiceTest.java
@@ -34,5 +34,4 @@ class JobServiceTest {
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("직무를 찾을 수 없습니다.");
     }
-
 }

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/JobServiceTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/JobServiceTest.java
@@ -1,0 +1,38 @@
+package net.blogteamthreecoderhivebe.domain.info.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import net.blogteamthreecoderhivebe.domain.info.entity.Job;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+class JobServiceTest {
+    @Autowired
+    JobService service;
+
+    @DisplayName("직무 조회 성공")
+    @CsvSource(value = {"1", "2", "3", "4", "5"})
+    @ParameterizedTest
+    void findJob(Long jobId) {
+        Job job = service.findOne(jobId);
+        assertThat(job.getId()).isEqualTo(jobId);
+    }
+
+    @DisplayName("존재하지 않는 직무를 조회할 경우 예외 발생")
+    @Test
+    void findJobEx() {
+        assertThatThrownBy(() -> service.findOne(1000L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("직무를 찾을 수 없습니다.");
+    }
+
+}

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/LocationServiceTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/LocationServiceTest.java
@@ -1,0 +1,38 @@
+package net.blogteamthreecoderhivebe.domain.info.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import net.blogteamthreecoderhivebe.domain.info.entity.Location;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+class LocationServiceTest {
+
+    @Autowired
+    LocationService service;
+
+    @DisplayName("지역 조회 성공")
+    @CsvSource({"1", "2", "3", "4", "5"})
+    @ParameterizedTest
+    void findLocation(Long locationId) {
+        Location location = service.findOne(locationId);
+        assertThat(location.getId()).isEqualTo(locationId);
+    }
+
+    @DisplayName("존재하지 않는 지역을 조회할 경우 예외 발생")
+    @Test
+    void findLocationEx() {
+        assertThatThrownBy(() -> service.findOne(10000L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("지역을 찾을 수 없습니다.");
+    }
+}

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/LocationServiceTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/LocationServiceTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Transactional
 @SpringBootTest
 class LocationServiceTest {
-
     @Autowired
     LocationService service;
 

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/SkillServiceTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/SkillServiceTest.java
@@ -1,0 +1,36 @@
+package net.blogteamthreecoderhivebe.domain.info.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import net.blogteamthreecoderhivebe.domain.info.entity.Skill;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+class SkillServiceTest {
+    @Autowired SkillService service;
+
+    @DisplayName("기술 조회 성공")
+    @CsvSource(value = {"1", "2", "3", "4", "5"})
+    @ParameterizedTest
+    void findSkill(Long skillId) {
+        Skill skill = service.findOne(skillId);
+        assertThat(skill.getId()).isEqualTo(skillId);
+    }
+
+    @DisplayName("존재하지 않는 기술을 조회할 경우 예외 발생")
+    @Test
+    void findSkillEx() {
+        assertThatThrownBy(() -> service.findOne(1000L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("기술을 찾을 수 없습니다.");
+    }
+}

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/SkillServiceTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/info/service/SkillServiceTest.java
@@ -16,7 +16,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Transactional
 @SpringBootTest
 class SkillServiceTest {
-    @Autowired SkillService service;
+    @Autowired
+    SkillService service;
 
     @DisplayName("기술 조회 성공")
     @CsvSource(value = {"1", "2", "3", "4", "5"})

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/member/dto/request/SignUpRequestTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/member/dto/request/SignUpRequestTest.java
@@ -1,0 +1,38 @@
+package net.blogteamthreecoderhivebe.domain.member.dto.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+class SignUpRequestTest {
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    public static void init() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @DisplayName("회원가입 DTO 필드값 검증(Validation)")
+    @Test
+    void notEmpty_validation() {
+        SignUpRequest signUpRequest01 = new SignUpRequest("Nickname", "4", "초보", "미지정");
+        SignUpRequest signUpRequest02 = new SignUpRequest("Nickname", "ab", "초보", "미지정");
+        Set<ConstraintViolation<SignUpRequest>> violations01 = validator.validate(signUpRequest01);
+        Set<ConstraintViolation<SignUpRequest>> violations02 = validator.validate(signUpRequest02);
+        for (ConstraintViolation<SignUpRequest> violation : violations01) {
+            System.err.println(violation.getMessage());
+        }
+        for (ConstraintViolation<SignUpRequest> violation : violations02) {
+            System.err.println(violation.getMessage());
+        }
+    }
+
+}

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/member/service/MemberServiceTest.java
@@ -1,14 +1,24 @@
 package net.blogteamthreecoderhivebe.domain.member.service;
 
+import net.blogteamthreecoderhivebe.domain.info.entity.Job;
+import net.blogteamthreecoderhivebe.domain.info.repository.JobRepository;
+import net.blogteamthreecoderhivebe.domain.member.dto.SignUpDto;
 import net.blogteamthreecoderhivebe.domain.member.entity.Member;
 import net.blogteamthreecoderhivebe.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
+import static net.blogteamthreecoderhivebe.domain.member.constant.MemberCareer.NON;
+import static net.blogteamthreecoderhivebe.domain.member.constant.MemberLevel.BEGINNER;
+import static net.blogteamthreecoderhivebe.domain.member.constant.MemberRole.GUEST;
+import static net.blogteamthreecoderhivebe.domain.member.constant.MemberRole.USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
@@ -18,6 +28,8 @@ class MemberServiceTest {
     MemberService memberService;
     @Autowired
     MemberRepository memberRepository;
+    @Autowired
+    JobRepository jobRepository;
 
     @DisplayName("신규 회원이면 true, 기존 회원이면 false 반환 확인")
     @CsvSource({
@@ -35,5 +47,38 @@ class MemberServiceTest {
         Boolean result = memberService.isNewMember(email);
 
         assertThat(result).isEqualTo(expected);
+    }
+
+    @DisplayName("신규 회원의 추가정보를 업데이트하는 기능 테스트")
+    @Test
+    void signUp() {
+        //최초 Guest 저장
+        Member guestMember = Member.builder()
+                .email("example@naver.com")
+                .memberRole(GUEST)
+                .build();
+        memberRepository.save(guestMember);
+
+        //회원가입 - 추가정보로 업데이트
+        SignUpDto signUpDto = SignUpDto.builder()
+                .email("example@naver.com")
+                .nickname("exampleNick")
+                .jobId(4)
+                .memberLevel(BEGINNER)
+                .memberCareer(NON)
+                .build();
+        memberService.signUp(signUpDto);
+
+        //DB에 업데이트 됐는지 확인
+        Optional<Member> oMember = memberRepository.findByEmail(guestMember.getEmail());
+        Member savedMember = oMember.get();
+        Job job = jobRepository.findById(signUpDto.jobId()).orElseThrow();
+
+        assertThat(savedMember.getEmail()).isEqualTo(signUpDto.email());
+        assertThat(savedMember.getNickname()).isEqualTo(signUpDto.nickname());
+        assertThat(savedMember.getJob()).isEqualTo(job);
+        assertThat(savedMember.getMemberRole()).isEqualTo(USER);
+        assertThat(savedMember.getLevel()).isEqualTo(signUpDto.memberLevel());
+        assertThat(savedMember.getCareer()).isEqualTo(signUpDto.memberCareer());
     }
 }

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/post/constant/PostCategoryTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/post/constant/PostCategoryTest.java
@@ -1,0 +1,31 @@
+package net.blogteamthreecoderhivebe.domain.post.constant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PostCategoryTest {
+
+    @DisplayName("카테고리 조회 성공")
+    @CsvSource({
+            "project, PROJECT",
+            "study, STUDY",
+    })
+    @ParameterizedTest
+    void findCategory(String key, PostCategory expected) {
+        PostCategory category = PostCategory.find(key);
+        assertThat(category).isEqualTo(expected);
+    }
+
+    @DisplayName("존재하지 않은 카테고리 조회 시 예외 발생")
+    @Test
+    void findCategoryEx() {
+        assertThatThrownBy(() -> PostCategory.find("sttuuddy"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("카테고리를 찾을 수 없습니다.");
+    }
+}

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/post/entity/PostTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/post/entity/PostTest.java
@@ -1,0 +1,14 @@
+package net.blogteamthreecoderhivebe.domain.post.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostTest {
+    @Test
+    void builderDefaultTest() {
+        Post post = Post.builder().build();
+        assertThat(post.getHearts()).isNotNull();
+        assertThat(post.getRecruitmentJobs()).isNotNull();
+    }
+}

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/post/service/RecruitmentJobServiceTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/post/service/RecruitmentJobServiceTest.java
@@ -1,0 +1,64 @@
+package net.blogteamthreecoderhivebe.domain.post.service;
+
+import net.blogteamthreecoderhivebe.domain.info.repository.JobRepository;
+import net.blogteamthreecoderhivebe.domain.info.repository.LocationRepository;
+import net.blogteamthreecoderhivebe.domain.member.entity.Member;
+import net.blogteamthreecoderhivebe.domain.member.repository.MemberRepository;
+import net.blogteamthreecoderhivebe.domain.post.entity.Post;
+import net.blogteamthreecoderhivebe.domain.post.entity.RecruitmentJob;
+import net.blogteamthreecoderhivebe.domain.post.repository.PostRepository;
+import net.blogteamthreecoderhivebe.domain.post.repository.RecruitmentJobRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.blogteamthreecoderhivebe.domain.post.dto.request.RecruitmentJobRequestDto.SaveRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class RecruitmentJobServiceTest {
+    @Autowired JobRepository jobRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired LocationRepository locationRepository;
+    @Autowired RecruitmentJobService recruitmentJobService;
+    @Autowired RecruitmentJobRepository recruitmentJobRepository;
+
+    Post post;
+
+    @BeforeEach
+    void setUp() {
+        post = postRepository.save(Post.builder()
+                .member(memberRepository.save(Member.builder()
+                        .email("test@test.com")
+                        .build()))
+                .job(jobRepository.findById(1L).get())
+                .location(locationRepository.findById(1L).get())
+                .build()
+        );
+    }
+
+    @DisplayName("모집 직무 저장 성공")
+    @Test
+    void save() {
+        // given
+        List<SaveRequest> saveRequests = new ArrayList<>();
+        saveRequests.add(new SaveRequest(1L, 1));
+        saveRequests.add(new SaveRequest(2L, 2));
+        saveRequests.add(new SaveRequest(3L, 3));
+
+        // when
+        recruitmentJobService.save(saveRequests, post);
+
+        // then
+        List<RecruitmentJob> findRecruitmentJobs = recruitmentJobRepository.findAll();
+        assertThat(findRecruitmentJobs).hasSize(3);
+    }
+}

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/post/service/RecruitmentSkillServiceTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/post/service/RecruitmentSkillServiceTest.java
@@ -1,0 +1,59 @@
+package net.blogteamthreecoderhivebe.domain.post.service;
+
+import net.blogteamthreecoderhivebe.domain.info.repository.JobRepository;
+import net.blogteamthreecoderhivebe.domain.info.repository.LocationRepository;
+import net.blogteamthreecoderhivebe.domain.member.entity.Member;
+import net.blogteamthreecoderhivebe.domain.member.repository.MemberRepository;
+import net.blogteamthreecoderhivebe.domain.post.entity.Post;
+import net.blogteamthreecoderhivebe.domain.post.entity.RecruitmentSkill;
+import net.blogteamthreecoderhivebe.domain.post.repository.PostRepository;
+import net.blogteamthreecoderhivebe.domain.post.repository.RecruitmentSkillRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class RecruitmentSkillServiceTest {
+    @Autowired JobRepository jobRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired LocationRepository locationRepository;
+    @Autowired RecruitmentSkillService recruitmentSkillService;
+    @Autowired RecruitmentSkillRepository recruitmentSkillRepository;
+
+    Post post;
+
+    @BeforeEach
+    void setUp() {
+        post = postRepository.save(Post.builder()
+                .member(memberRepository.save(Member.builder()
+                        .email("test@test.com")
+                        .build()))
+                .job(jobRepository.findById(1L).get())
+                .location(locationRepository.findById(1L).get())
+                .build()
+        );
+    }
+
+    @DisplayName("모집 기술 저장 성공")
+    @Test
+    void save() {
+        // given
+        List<Long> skillIds = List.of(1L, 2L, 3L);
+
+        // when
+        recruitmentSkillService.save(skillIds, post);
+
+        // then
+        List<RecruitmentSkill> findRecruitmentSkills = recruitmentSkillRepository.findAll();
+        assertThat(findRecruitmentSkills).hasSize(3);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  profiles:
+    include: oauth
+    active: test
+
+  jpa:
+    defer-datasource-initialization: true # Hibernate 초기화전 이전에 sql 스크립트 실행
+
+logging:
+  level:
+    org.hibernate:
+      SQL: debug


### PR DESCRIPTION
## Summary
회원 등록 기능 수정 및 사용자 유효성(유저, 게스트) 검사 요청 기능 구현

## Describe your changes
- [X] 회원 가입 및 사용자 유효성(USER or QUEST) 판단을 위한 기능을 위한 DTO를 추가하였습니다.
`SignUpDto`, `SignUpResponse`
  - Validation 로직 추가
- [X] 회원 가입 로직 변경하였습니다.
  - 회원 가입에 Service 메소드를 호출하는 과정에서 `SignUpRequest`와 `MemberPrinciple`을 `SignUpDto`로 감싸서 전달하도록 수정하였습니다.
  - `SignUpDto` + `Job` -> `Member` 엔티티로 변환하는 메소드 추가하였습니다.
  - `DB` 저장 이후 `Member` 엔티티를 `SignUpResponse`로 변환하여 반환하도록 하였습니다.
- [X] 사용자 유효성 검사 요청 기능을 구현하였습니다.
  - `email`을 받아서 해당 사용자의 `ROLE`을 검사한 이후에 `SignUpResponse`를 반환하도록 하였습니다.
- [X] 테스트 코드 추가
  - `SignUpRequestTest` 필드값 검증 테스트
  - `MemberServiceTest` 회원가입 기능 테스트

## Issue number and link
#51 

## TODO
- 사용자 유효성 검사 요청 기능에 검증 로직 추가
  - 소셜 로그인 여부 확인 로직 추가
  - 유효성 검증 대상(email)과 로그인 유저(MemberPrincipal)이 동일한 지 검증 로직 추가