### PR TITLE
[Refactor] 생성자, 수정자 필드에 현재 로그인된 회원의 email 값을 넣어주도록 변경

### DIFF
--- a/src/main/java/net/blogteamthreecoderhivebe/global/config/JpaConfig.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/config/JpaConfig.java
@@ -1,21 +1,24 @@
 package net.blogteamthreecoderhivebe.global.config;
 
+import net.blogteamthreecoderhivebe.global.auth.dto.MemberPrincipal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @EnableJpaAuditing
 @Configuration
 public class JpaConfig {
     @Bean
     public AuditorAware<String> auditorProvider() {
-        return () -> Optional.of(UUID.randomUUID().toString());
-
-        // 추후 Spring Security의 Authentication을 가져와서 사용자명을 반환하도록 변경 예정
-        // return () -> Optional.of(SecurityContextHolder.getContext().getAuthentication().getName());
+        return () -> {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
+            return Optional.of(principal.getEmail());
+        };
     }
 }


### PR DESCRIPTION
## Summary
JPA의 Auditing 기능을 사용해`created_by`, `modified_by` 칼럼에 현재 로그인된 회원의 email 값을 넣어주도록 변경

## Describe your changes
- 기존에는 생성자, 수정자로 고유한 UUID를 생성해 넣어주었지만, 스프링 시큐리티 인증 객체를 사용해 현재 로그인 된 회원의 email 값을 가져와 넣어주도록 변경하였습니다.
- 람다를 사용해 다음과 같이 구현하였습니다.
```java
public AuditorAware<String> auditorProvider() {
    return () -> {
        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
        MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
        return Optional.of(principal.getEmail());
    };
}
```

## Test Checklist
