### PR TITLE
[Fix] 신규 회원 로그인 시 Authentication NPE 이슈 해결

### DIFF
--- a/src/main/java/net/blogteamthreecoderhivebe/domain/comment/entity/Comment.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/comment/entity/Comment.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import net.blogteamthreecoderhivebe.domain.member.entity.Member;
 import net.blogteamthreecoderhivebe.domain.post.entity.Post;
-import net.blogteamthreecoderhivebe.global.common.AuditingFields;
+import net.blogteamthreecoderhivebe.global.common.BaseEntity;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -13,7 +13,7 @@ import java.util.Set;
 @ToString(callSuper = true, exclude = {"member", "post", "childComments"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Comment extends AuditingFields {
+public class Comment extends BaseEntity {
     @Id
     @Column(name = "comment_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/constant/MemberRole.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/constant/MemberRole.java
@@ -13,4 +13,8 @@ public enum MemberRole {
     MemberRole(String description) {
         this.description = description;
     }
+
+    public boolean isGuest() {
+        return this == GUEST;
+    }
 }

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/member/entity/Member.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/member/entity/Member.java
@@ -7,7 +7,7 @@ import net.blogteamthreecoderhivebe.domain.info.entity.Job;
 import net.blogteamthreecoderhivebe.domain.member.constant.MemberCareer;
 import net.blogteamthreecoderhivebe.domain.member.constant.MemberLevel;
 import net.blogteamthreecoderhivebe.domain.member.constant.MemberRole;
-import net.blogteamthreecoderhivebe.global.common.AuditingFields;
+import net.blogteamthreecoderhivebe.global.common.BaseTimeEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import static net.blogteamthreecoderhivebe.domain.member.constant.MemberRole.USE
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
-public class Member extends AuditingFields {
+public class Member extends BaseTimeEntity {
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/net/blogteamthreecoderhivebe/domain/post/entity/Post.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/domain/post/entity/Post.java
@@ -9,7 +9,7 @@ import net.blogteamthreecoderhivebe.domain.info.entity.Skill;
 import net.blogteamthreecoderhivebe.domain.member.entity.Member;
 import net.blogteamthreecoderhivebe.domain.post.constant.PostCategory;
 import net.blogteamthreecoderhivebe.domain.post.constant.PostStatus;
-import net.blogteamthreecoderhivebe.global.common.AuditingFields;
+import net.blogteamthreecoderhivebe.global.common.BaseEntity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,7 +21,7 @@ import java.util.List;
 @ToString(callSuper = true, exclude = {"member", "job", "location", "hearts", "recruitJobs", "recruitSkills"})
 @Table(indexes = @Index(columnList = "modifiedAt DESC"))
 @Entity
-public class Post extends AuditingFields {
+public class Post extends BaseEntity {
     @Id
     @Column(name = "post_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/net/blogteamthreecoderhivebe/global/auth/dto/MemberPrincipal.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/auth/dto/MemberPrincipal.java
@@ -14,7 +14,6 @@ public class MemberPrincipal extends DefaultOAuth2User {
 
     public MemberPrincipal(SocialLoginDto socialLoginDto, MemberRole memberRole) {
         super(
-                // 지금은 인증만 하고 권한을 다루고 있지 않아서 임의로 세팅
                 Collections.singleton(new SimpleGrantedAuthority(memberRole.getDescription())),
                 socialLoginDto.attributes(),
                 socialLoginDto.nameAttributeKey()

--- a/src/main/java/net/blogteamthreecoderhivebe/global/auth/dto/MemberPrincipal.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/auth/dto/MemberPrincipal.java
@@ -22,4 +22,8 @@ public class MemberPrincipal extends DefaultOAuth2User {
         this.email = socialLoginDto.email();
         this.memberRole = memberRole;
     }
+
+    public boolean isGuest() {
+        return memberRole.isGuest();
+    }
 }

--- a/src/main/java/net/blogteamthreecoderhivebe/global/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/auth/handler/OAuth2SuccessHandler.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.blogteamthreecoderhivebe.domain.member.constant.MemberRole;
 import net.blogteamthreecoderhivebe.domain.member.service.MemberService;
 import net.blogteamthreecoderhivebe.global.auth.dto.MemberPrincipal;
 import org.springframework.security.core.Authentication;
@@ -14,8 +13,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-
-import static net.blogteamthreecoderhivebe.domain.member.constant.MemberRole.GUEST;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,13 +25,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
         MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
-        MemberRole memberRole = principal.getMemberRole();
         String email = principal.getEmail();
 
         log.info("oauth login success : {} {}",email, authentication.getAuthorities());
 
         String redirectUrl;
-        if (isGuest(memberRole)) {
+        if (principal.isGuest()) {
             // GUEST일 경우 회원 가입 페이지로 이동
             redirectUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/register")
                     .queryParam("email", email)
@@ -45,9 +41,5 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         }
 
         getRedirectStrategy().sendRedirect(request, response, redirectUrl);
-    }
-
-    private boolean isGuest(MemberRole memberRole) {
-        return memberRole == GUEST;
     }
 }

--- a/src/main/java/net/blogteamthreecoderhivebe/global/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/auth/handler/OAuth2SuccessHandler.java
@@ -1,11 +1,9 @@
 package net.blogteamthreecoderhivebe.global.auth.handler;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.blogteamthreecoderhivebe.domain.member.service.MemberService;
 import net.blogteamthreecoderhivebe.global.auth.dto.MemberPrincipal;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -18,23 +16,23 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @Component
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-    private final MemberService memberService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
-                                        Authentication authentication) throws IOException, ServletException {
+                                        Authentication authentication) throws IOException {
         MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
         String email = principal.getEmail();
 
-        log.info("oauth login success : {} {}",email, authentication.getAuthorities());
+        log.info("oauth login success : {} {}", email, authentication.getAuthorities());
 
         String redirectUrl;
         if (principal.isGuest()) {
             // GUEST일 경우 회원 가입 페이지로 이동
             redirectUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/register")
                     .queryParam("email", email)
-                    .build().toUriString();
+                    .build()
+                    .toUriString();
         } else {
             // USER일 경우 홈로 이동
             redirectUrl = "http://localhost:3000";

--- a/src/main/java/net/blogteamthreecoderhivebe/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/auth/service/CustomOAuth2UserService.java
@@ -1,7 +1,6 @@
 package net.blogteamthreecoderhivebe.global.auth.service;
 
 import lombok.RequiredArgsConstructor;
-import net.blogteamthreecoderhivebe.domain.member.constant.MemberRole;
 import net.blogteamthreecoderhivebe.domain.member.entity.Member;
 import net.blogteamthreecoderhivebe.domain.member.repository.MemberRepository;
 import net.blogteamthreecoderhivebe.global.auth.dto.MemberPrincipal;
@@ -35,8 +34,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         SocialLoginDto socialLoginDto = SocialLoginDto.of(registrationId, nameAttributeKey, attributes);
         //System.out.println("socialLoginDto : " + socialLoginDto);
 
-        MemberRole memberRole = saveOrUpdate(socialLoginDto).getMemberRole();
-        return new MemberPrincipal(socialLoginDto, memberRole);
+        Member member = saveOrUpdate(socialLoginDto);
+        return new MemberPrincipal(socialLoginDto, member.getMemberRole());
     }
 
     private Member saveOrUpdate(SocialLoginDto socialLoginDto) {

--- a/src/main/java/net/blogteamthreecoderhivebe/global/common/AuditingFields.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/common/AuditingFields.java
@@ -21,19 +21,18 @@ import java.time.LocalDateTime;
 public abstract class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
-    @Column(nullable = false, updatable = false)
+    @Column(updatable = false)
     protected LocalDateTime createdAt; // 생성일시
 
     @CreatedBy
-    @Column(nullable = false, length = 100, updatable = false)
+    @Column(length = 100, updatable = false)
     protected String createdBy; // 생성자
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
-    @Column(nullable = false)
-    protected LocalDateTime modifiedAt; //수정일시
+    protected LocalDateTime modifiedAt; // 수정일시
 
     @LastModifiedBy
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     protected String modifiedBy; // 수정자
 }

--- a/src/main/java/net/blogteamthreecoderhivebe/global/common/BaseEntity.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/common/BaseEntity.java
@@ -1,0 +1,23 @@
+package net.blogteamthreecoderhivebe.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity extends BaseTimeEntity {
+
+    @Column(length = 100, updatable = false)
+    @CreatedBy
+    protected String createdBy;
+
+    @Column(length = 100)
+    @LastModifiedBy
+    protected String modifiedBy;
+}

--- a/src/main/java/net/blogteamthreecoderhivebe/global/common/BaseTimeEntity.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/common/BaseTimeEntity.java
@@ -4,10 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -15,24 +12,16 @@ import org.springframework.format.annotation.DateTimeFormat;
 import java.time.LocalDateTime;
 
 @Getter
-@ToString
-@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public abstract class AuditingFields {
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    @CreatedDate
-    @Column(updatable = false)
-    protected LocalDateTime createdAt; // 생성일시
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
 
-    @CreatedBy
-    @Column(length = 100, updatable = false)
-    protected String createdBy; // 생성자
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @Column(updatable = false)
+    @CreatedDate
+    protected LocalDateTime createdAt;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
-    protected LocalDateTime modifiedAt; // 수정일시
-
-    @LastModifiedBy
-    @Column(length = 100)
-    protected String modifiedBy; // 수정자
+    protected LocalDateTime modifiedAt;
 }

--- a/src/main/java/net/blogteamthreecoderhivebe/global/config/JpaConfig.java
+++ b/src/main/java/net/blogteamthreecoderhivebe/global/config/JpaConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
 
 import java.util.Optional;
 
@@ -17,8 +18,13 @@ public class JpaConfig {
     public AuditorAware<String> auditorProvider() {
         return () -> {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
-            return Optional.of(principal.getEmail());
+
+            if (ObjectUtils.isEmpty(authentication)) {
+                return Optional.empty();
+            } else {
+                MemberPrincipal principal = (MemberPrincipal) authentication.getPrincipal();
+                return Optional.of(principal.getEmail());
+            }
         };
     }
 }

--- a/src/test/java/net/blogteamthreecoderhivebe/domain/member/constant/MemberRoleTest.java
+++ b/src/test/java/net/blogteamthreecoderhivebe/domain/member/constant/MemberRoleTest.java
@@ -1,0 +1,16 @@
+package net.blogteamthreecoderhivebe.domain.member.constant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberRoleTest {
+
+    @DisplayName("게스트인지 아닌지 확인한다.")
+    @Test
+    void isGuest() {
+        assertThat(MemberRole.GUEST.isGuest()).isTrue();
+        assertThat(MemberRole.USER.isGuest()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
신규 회원 로그인 시 DB에 insert가 일어나는데 생성자, 수정자 필드를 Auditing 받는 로직에서 `Authentication Null Point Exception` 에러가 발생하는 문제를 해결하였습니다.

## Describe your changes
- Authentication이 없을 경우 `Optional.empty()`를 반환해 NPE가 발생하지 않도록 변경
- Auditing 필드에 null을 허용하도록 변경 
- 생성자, 수정자 필드를 선택적으로 사용할 수 있도록 기존에 `AuditingFields`를 `BaseEntity`, `BaseTimeEntity`로 분기하여 적용
  - null 허용으로 해결하다보니 Member의 생성자 필드는 항상 null로 들어가는 것을 확인
  - 보통 Member에는 생성자, 수정자를 두지 않는 경우가 많다고 하여 생성일, 수정일 필드만을 포함하도록 변경
